### PR TITLE
Add new `Node#toPair()` class method (#3)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -17,6 +17,10 @@ class Node {
   set value(value) {
     this._value = value;
   }
+
+  toPair() {
+    return [this.key, this.value];
+  }
 }
 
 module.exports = Node;

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -6,6 +6,7 @@ declare namespace node {
   export interface Instance<T> {
     value: T;
     readonly key: number;
+    toPair(): [number, T];
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Node#toPair()`

The method returns an ordered-pair/2-tuple, where the first element is a number corresponding to the `key` of the node, and the last one is a value, that can be of any type, corresponding to the `value` stored in the node.

Also, the corresponding TypeScript ambient declarations are included in the PR.
