### PR TITLE
Add new `Heap#isEmpty()` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -8,6 +8,10 @@ class Heap {
   get size() {
     return this._data.length;
   }
+
+  isEmpty() {
+    return this._data.length === 0;
+  }
 }
 
 module.exports = Heap;

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -17,6 +17,7 @@ declare namespace heap {
 
   export interface Instance<T> {
     readonly size: number;
+    isEmpty(): boolean;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary predicate method: 

- `Heap#isEmpty()`

The method returns `true`, if the heap is empty, or `false` if it is not.

Also, the corresponding TypeScript ambient declarations are included in the PR.
