### PR TITLE
Add new `Heap#includes(key)` unary predicate class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -18,6 +18,16 @@ class Heap {
     return this;
   }
 
+  includes(key) {
+    for (const node of this._data) {
+      if (node.key === key) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   isEmpty() {
     return this._data.length === 0;
   }

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -21,6 +21,7 @@ declare namespace heap {
     readonly root: Node<T> | undefined;
     readonly size: number;
     clear(): this;
+    includes(key: number): boolean;
     isEmpty(): boolean;
     toArray(): Node<T>[];
   }


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `Heap#includes(key)`

Determines whether the heap includes a node with a certain key value, returning true or false as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.
