### PR TITLE
Add new `Heap#toPairs()` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -37,6 +37,12 @@ class Heap {
     this._data.forEach(node => array.push(node));
     return array;
   }
+
+  toPairs() {
+    const array = [];
+    this._data.forEach(node => array.push(node.toPair()));
+    return array;
+  }
 }
 
 module.exports = Heap;

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -24,6 +24,7 @@ declare namespace heap {
     includes(key: number): boolean;
     isEmpty(): boolean;
     toArray(): Node<T>[];
+    toPairs(): [number, T][];
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Heap#toPairs()`

Applies level-order traversal to the heap and for each traversed node stores in an `n`-tuple, where `n` the size of the heap, an ordered-pair/2-tuple, where the first element is a `number` corresponding to the `key` of the traversed node, and the last one is a value of type `any`, corresponding to the `value` stored in the traversed node.
The `n`-tuple is returned at the end of the traversal.

Also, the corresponding TypeScript ambient declarations are included in the PR.
