### PR TITLE
Add new `Heap#search(key)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -32,6 +32,16 @@ class Heap {
     return this._data.length === 0;
   }
 
+  search(key) {
+    for (const node of this._data) {
+      if (node.key === key) {
+        return node;
+      }
+    }
+
+    return undefined;
+  }
+
   toArray() {
     const array = [];
     this._data.forEach(node => array.push(node));

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -23,6 +23,7 @@ declare namespace heap {
     clear(): this;
     includes(key: number): boolean;
     isEmpty(): boolean;
+    search(key: number): Node<T> | undefined;
     toArray(): Node<T>[];
     toPairs(): [number, T][];
   }


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#search(key)`

Determines whether the heap includes a node with a certain `key`, returning the targeted node or `undefined` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.
