### PR TITLE
Add new `Heap#keys()` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -32,6 +32,12 @@ class Heap {
     return this._data.length === 0;
   }
 
+  keys() {
+    const array = [];
+    this._data.forEach(node => array.push(node.key));
+    return array;
+  }
+
   search(key) {
     for (const node of this._data) {
       if (node.key === key) {

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -23,6 +23,7 @@ declare namespace heap {
     clear(): this;
     includes(key: number): boolean;
     isEmpty(): boolean;
+    keys(): number[];
     search(key: number): Node<T> | undefined;
     toArray(): Node<T>[];
     toPairs(): [number, T][];


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Tree#keys()`

Applies level-order traversal to the heap and for each traversed node stores in an array of length `n`, where `n` the size of the heap, a `number` corresponding to the `key` of the traversed node.
The array is returned at the end of the traversal.

Also, the corresponding TypeScript ambient declarations are included in the PR.
