### PR TITLE
Add new `Heap#values()` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -59,6 +59,12 @@ class Heap {
     this._data.forEach(node => array.push(node.toPair()));
     return array;
   }
+
+  values() {
+    const array = [];
+    this._data.forEach(node => array.push(node.value));
+    return array;
+  }
 }
 
 module.exports = Heap;

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -27,6 +27,7 @@ declare namespace heap {
     search(key: number): Node<T> | undefined;
     toArray(): Node<T>[];
     toPairs(): [number, T][];
+    values(): T[];
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Heap#values()`

Applies level-order traversal to the heap and for each traversed node stores in an array of length `n`, where `n` the size of the heap, a value, of any type, corresponding to the `value` of the traversed node.
The array is returned at the end of the traversal.

Also, the corresponding TypeScript ambient declarations are included in the PR.
