### PR TITLE
Add new `Heap#node(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -38,6 +38,10 @@ class Heap {
     return array;
   }
 
+  node(index) {
+    return this._data[index];
+  }
+
   search(key) {
     for (const node of this._data) {
       if (node.key === key) {

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -24,6 +24,7 @@ declare namespace heap {
     includes(key: number): boolean;
     isEmpty(): boolean;
     keys(): number[];
+    node(index: number): Node<T> | undefined;
     search(key: number): Node<T> | undefined;
     toArray(): Node<T>[];
     toPairs(): [number, T][];


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#node(index)`

Returns the node corresponding to the given index of the unique zero-indexed array representation of the binary heap. The representation results from storing the level order traversal of the heap in an array.

Also, the corresponding TypeScript ambient declarations are included in the PR.
