### PR TITLE
Add new `Heap#right(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -42,6 +42,10 @@ class Heap {
     return this._data[index];
   }
 
+  right(index) {
+    return this._data[(2 * index) + 2];
+  }
+
   search(key) {
     for (const node of this._data) {
       if (node.key === key) {

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -25,6 +25,7 @@ declare namespace heap {
     isEmpty(): boolean;
     keys(): number[];
     node(index: number): Node<T> | undefined;
+    right(index: number): Node<T> | undefined;
     search(key: number): Node<T> | undefined;
     toArray(): Node<T>[];
     toPairs(): [number, T][];


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#right(index)`

Returns the right child of the parent node corresponding to the given index of the unique zero-indexed array representation of the binary heap. The representation results from storing the level order traversal of the heap in an array. If the right child of the targeted parent node does not exist then `undefined` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.
