### PR TITLE
Add new `Heap#left(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -38,6 +38,10 @@ class Heap {
     return array;
   }
 
+  left(index) {
+    return this._data[(2 * index) + 1];
+  }
+
   node(index) {
     return this._data[index];
   }

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -24,6 +24,7 @@ declare namespace heap {
     includes(key: number): boolean;
     isEmpty(): boolean;
     keys(): number[];
+    left(index: number): Node<T> | undefined;
     node(index: number): Node<T> | undefined;
     right(index: number): Node<T> | undefined;
     search(key: number): Node<T> | undefined;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#left(index)`

Returns the left child of the parent node corresponding to the given index of the unique zero-indexed array representation of the binary heap. The representation results from storing the level order traversal of the heap in an array. If the left child of the targeted parent node does not exist then `undefined` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.
