### PR TITLE
Add new `Heap#parent(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -46,6 +46,10 @@ class Heap {
     return this._data[index];
   }
 
+  parent(index) {
+    return this._data[Math.floor((index - 1) / 2)];
+  }
+
   right(index) {
     return this._data[(2 * index) + 2];
   }

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -26,6 +26,7 @@ declare namespace heap {
     keys(): number[];
     left(index: number): Node<T> | undefined;
     node(index: number): Node<T> | undefined;
+    parent(index: number): Node<T> | undefined;
     right(index: number): Node<T> | undefined;
     search(key: number): Node<T> | undefined;
     toArray(): Node<T>[];


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#parent(index)`

Returns the parent of the node corresponding to the given index of the unique zero-indexed array representation of the binary heap. The representation results from storing the level order traversal of the heap in an array. If the parent of the targeted parent node does not exist then `undefined` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.
