### PR TITLE
Add new `Heap#parentIndex(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -50,6 +50,10 @@ class Heap {
     return this._data[Math.floor((index - 1) / 2)];
   }
 
+  parentIndex(index) {
+    return Math.floor((index - 1) / 2);
+  }
+
   right(index) {
     return this._data[(2 * index) + 2];
   }

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -27,6 +27,7 @@ declare namespace heap {
     left(index: number): Node<T> | undefined;
     node(index: number): Node<T> | undefined;
     parent(index: number): Node<T> | undefined;
+    parentIndex(index: number): number;
     right(index: number): Node<T> | undefined;
     search(key: number): Node<T> | undefined;
     toArray(): Node<T>[];


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#parentIndex(index)`

Returns the parent index of the node corresponding to the given index of the unique zero-indexed array representation of the binary heap. The representation results from storing the level order traversal of the heap in an array.

Also, the corresponding TypeScript ambient declarations are included in the PR.
