### PR TITLE
Add new `Heap#rightIndex(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -58,6 +58,10 @@ class Heap {
     return this._data[(2 * index) + 2];
   }
 
+  rightIndex(index) {
+    return (2 * index) + 2;
+  }
+
   search(key) {
     for (const node of this._data) {
       if (node.key === key) {

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -29,6 +29,7 @@ declare namespace heap {
     parent(index: number): Node<T> | undefined;
     parentIndex(index: number): number;
     right(index: number): Node<T> | undefined;
+    rightIndex(index: number): number;
     search(key: number): Node<T> | undefined;
     toArray(): Node<T>[];
     toPairs(): [number, T][];


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#rightIndex(index)`

Returns the right child index of the node corresponding to the given index of the unique zero-indexed array representation of the binary heap. The representation results from storing the level order traversal of the heap in an array.

Also, the corresponding TypeScript ambient declarations are included in the PR.
