### PR TITLE
Add new `Heap#leftIndex(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -42,6 +42,10 @@ class Heap {
     return this._data[(2 * index) + 1];
   }
 
+  leftIndex(index) {
+    return (2 * index) + 1;
+  }
+
   node(index) {
     return this._data[index];
   }

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -25,6 +25,7 @@ declare namespace heap {
     isEmpty(): boolean;
     keys(): number[];
     left(index: number): Node<T> | undefined;
+    leftIndex(index: number): number;
     node(index: number): Node<T> | undefined;
     parent(index: number): Node<T> | undefined;
     parentIndex(index: number): number;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#leftIndex(index)`

Returns the left child index of the node corresponding to the given index of the unique zero-indexed array representation of the binary heap. The representation results from storing the level order traversal of the heap in an array.

Also, the corresponding TypeScript ambient declarations are included in the PR.
