### PR TITLE
Add new `Heap#children(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -13,6 +13,23 @@ class Heap {
     return this._data.length;
   }
 
+  children(index) {
+    const children = [];
+
+    const left = this.left(index);
+    const right = this.right(index);
+
+    if (left) {
+      children.push(left);
+    }
+
+    if (right) {
+      children.push(right);
+    }
+
+    return children;
+  }
+
   clear() {
     this._data = [];
     return this;

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -20,6 +20,7 @@ declare namespace heap {
   export interface Instance<T> {
     readonly root: Node<T> | undefined;
     readonly size: number;
+    children(index: number): Node<T>[];
     clear(): this;
     includes(key: number): boolean;
     isEmpty(): boolean;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#children(index)`

Returns an array contacting the children of the parent node, corresponding to the given index of the unique zero-indexed array representation of the binary heap, where the left child, if present, is the first element of the array, and the right child, if present, is the last element of the array.

Also, the corresponding TypeScript ambient declarations are included in the PR.