### PR TITLE
Add new `Heap#isLeaf(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -49,6 +49,10 @@ class Heap {
     return this._data.length === 0;
   }
 
+  isLeaf(index) {
+    return !this.left(index) && !this.right(index);
+  }
+
   keys() {
     const array = [];
     this._data.forEach(node => array.push(node.key));

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -24,6 +24,7 @@ declare namespace heap {
     clear(): this;
     includes(key: number): boolean;
     isEmpty(): boolean;
+    isLeaf(index: number): boolean;
     keys(): number[];
     left(index: number): Node<T> | undefined;
     leftIndex(index: number): number;


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `Heap#isLeaf(index)`

Returns `true` if parent node, corresponding to the given index of the unique zero-indexed array representation of the binary heap, has no children nodes. Returns `false` in any other case.

Also, the corresponding TypeScript ambient declarations are included in the PR.