### PR TITLE
Add new `Heap#degree(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -35,6 +35,10 @@ class Heap {
     return this;
   }
 
+  degree(index) {
+    return this.children(index).length;
+  }
+
   includes(key) {
     for (const node of this._data) {
       if (node.key === key) {

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -24,6 +24,7 @@ declare namespace heap {
     readonly size: number;
     children(index: number): Node<T>[];
     clear(): this;
+    degree(index: number): Degree;
     includes(key: number): boolean;
     isEmpty(): boolean;
     isLeaf(index: number): boolean;


### PR DESCRIPTION
## Description

The PR introduces the following unary class method: 

- `Heap#degree(index)`

Return the degree of the node, corresponding to the given index of the unique zero-indexed array representation of the binary heap, which can be: `0`, `1` or `2`.

Also, the corresponding TypeScript ambient declarations are included in the PR.
