### PR TITLE
Add new `Heap#indexOf(key)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -49,6 +49,20 @@ class Heap {
     return false;
   }
 
+  indexOf(key) {
+    let index = 0;
+
+    for (const node of this._data) {
+      if (node.key === key) {
+        return index;
+      }
+
+      index += 1;
+    }
+
+    return -1;
+  }
+
   isEmpty() {
     return this._data.length === 0;
   }

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -26,6 +26,7 @@ declare namespace heap {
     clear(): this;
     degree(index: number): Degree;
     includes(key: number): boolean;
+    indexOf(key: number): number;
     isEmpty(): boolean;
     isLeaf(index: number): boolean;
     keys(): number[];


### PR DESCRIPTION
## Description

The PR introduces the following unary class method: 

- `Heap#indexOf(key)`

Returns the index, in the unique zero-indexed array representation of the binary heap, of the node corresponding to the given `key` argument. If the `key` does not correspond to any node then the value `-1` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.
