### PR TITLE
Add new `Heap#isFullNode(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -67,6 +67,10 @@ class Heap {
     return this._data.length === 0;
   }
 
+  isFullNode(index) {
+    return this.left(index) !== undefined && this.right(index) !== undefined;
+  }
+
   isLeafNode(index) {
     return !this.left(index) && !this.right(index);
   }

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -28,6 +28,7 @@ declare namespace heap {
     includes(key: number): boolean;
     indexOf(key: number): number;
     isEmpty(): boolean;
+    isFullNode(index: number): boolean;
     isLeafNode(index: number): boolean;
     keys(): number[];
     left(index: number): Node<T> | undefined;


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `Heap#isFullNode(index)`

Returns `true` if the node, corresponding to the given index of the unique zero-indexed array representation of the binary heap, has two node children. Returns `false` in any other case.

Also, the corresponding TypeScript ambient declarations are included in the PR.