### PR TITLE
Add new `Heap#isInternalNode(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -71,6 +71,10 @@ class Heap {
     return this.left(index) !== undefined && this.right(index) !== undefined;
   }
 
+  isInternalNode(index) {
+    return this.left(index) !== undefined || this.right(index) !== undefined;
+  }
+
   isLeafNode(index) {
     return !this.left(index) && !this.right(index);
   }

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -29,6 +29,7 @@ declare namespace heap {
     indexOf(key: number): number;
     isEmpty(): boolean;
     isFullNode(index: number): boolean;
+    isInternalNode(index: number): boolean;
     isLeafNode(index: number): boolean;
     keys(): number[];
     left(index: number): Node<T> | undefined;


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `Heap#isInternalNode(index)`

Returns `true` if the node, corresponding to the given index of the unique zero-indexed array representation of the binary heap, has at least one node child. Returns `false` in any other case.

Also, the corresponding TypeScript ambient declarations are included in the PR.