### PR TITLE
Add new `Heap#isPartialNode(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -79,6 +79,10 @@ class Heap {
     return !this.left(index) && !this.right(index);
   }
 
+  isPartialNode(index) {
+    this.degree(index) === 1;
+  }
+
   keys() {
     const array = [];
     this._data.forEach(node => array.push(node.key));

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -31,6 +31,7 @@ declare namespace heap {
     isFullNode(index: number): boolean;
     isInternalNode(index: number): boolean;
     isLeafNode(index: number): boolean;
+    isPartialNode(index: number): boolean;
     keys(): number[];
     left(index: number): Node<T> | undefined;
     leftIndex(index: number): number;


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `Heap#isPartialNode(index)`

Returns `true` if the node, corresponding to the given index of the unique zero-indexed array representation of the binary heap, has exactly one child node. Returns `false` in any other case.

Also, the corresponding TypeScript ambient declarations are included in the PR.