### PR TITLE
Add new `Heap#height()` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -39,6 +39,10 @@ class Heap {
     return this.children(index).length;
   }
 
+  height() {
+    return Math.ceil(Math.log2(this.size + 1)) - 1;
+  }
+
   includes(key) {
     for (const node of this._data) {
       if (node.key === key) {

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -25,6 +25,7 @@ declare namespace heap {
     children(index: number): Node<T>[];
     clear(): this;
     degree(index: number): Degree;
+    height(): number;
     includes(key: number): boolean;
     indexOf(key: number): number;
     isEmpty(): boolean;


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Heap#height()`

The method returns the maximum distance of any node from the root, also knows as the height of the binary heap. If the heap is empty `-1` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.
