### PR TITLE
Add new `Heap#internalNode()` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -79,6 +79,18 @@ class Heap {
     return -1;
   }
 
+  internalNodes() {
+    const nodes = [];
+
+    this._data.forEach((node, index) => {
+      if (this.isInternalNode(index)) {
+        nodes.push(node);
+      }
+    });
+
+    return nodes;
+  }
+
   isEmpty() {
     return this._data.length === 0;
   }

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -29,6 +29,7 @@ declare namespace heap {
     height(): number;
     includes(key: number): boolean;
     indexOf(key: number): number;
+    internalNodes(): Node<T>[];
     isEmpty(): boolean;
     isFullNode(index: number): boolean;
     isInternalNode(index: number): boolean;


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Heap#internalNodes()`

Applies level-order traversal to the heap and stores each traversed internal node in an array.
The array is returned at the end of the traversal.

Also, the corresponding TypeScript ambient declarations are included in the PR.
