### PR TITLE
Add new `Heap#partialNodes()` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -149,6 +149,18 @@ class Heap {
     return Math.floor((index - 1) / 2);
   }
 
+  partialNodes() {
+    const nodes = [];
+
+    this._data.forEach((node, index) => {
+      if (this.isPartialNode(index)) {
+        nodes.push(node);
+      }
+    });
+
+    return nodes;
+  }
+
   right(index) {
     return this._data[this.rightIndex(index)];
   }

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -42,6 +42,7 @@ declare namespace heap {
     node(index: number): Node<T> | undefined;
     parent(index: number): Node<T> | undefined;
     parentIndex(index: number): number;
+    partialNodes(): Node<T>[];
     right(index: number): Node<T> | undefined;
     rightIndex(index: number): number;
     search(key: number): Node<T> | undefined;


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Heap#partialNodes()`

Applies level-order traversal to the heap and stores each traversed partial node in an array.
The array is returned at the end of the traversal.

Also, the corresponding TypeScript ambient declarations are included in the PR.
