### PR TITLE
Add new `Max#insert(key, value)` class method (#3)

### DIFF
--- a/src/max.js
+++ b/src/max.js
@@ -1,9 +1,26 @@
 'use strict';
 const Heap = require('./heap');
+const Node = require('./node');
 
 class Max extends Heap {
   _areOrdered(parentIndex, childIndex) {
     return this._data[parentIndex].key - this._data[childIndex].key > 0;
+  }
+
+  insert(key, value) {
+    const node = new Node(key, value);
+    this._data.push(node);
+
+    let index = this.size - 1;
+    let parentIndex = this.parentIndex(index);
+
+    while (parentIndex >= 0 && !this._areOrdered(parentIndex, index)) {
+      this._swap(parentIndex, index);
+      index = parentIndex;
+      parentIndex = this.parentIndex(index);
+    }
+
+    return this;
   }
 }
 

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -54,7 +54,9 @@ declare namespace max {
     new <T = any>(): Instance<T>;
   }
 
-  export interface Instance<T = any> extends heap.Instance<T> {}
+  export interface Instance<T = any> extends heap.Instance<T> {
+    insert(key: number, value: T): this;
+  }
 }
 
 declare namespace min {


### PR DESCRIPTION
## Description

The PR introduces the following new binary method: 

- `Max#insert(key, value)`

Mutates the max heap by inserting a new at the appropriate location. Returns the max heap itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
