### PR TITLE
Add new `Min#insert(key, value)` class method (#3)

### DIFF
--- a/src/min.js
+++ b/src/min.js
@@ -1,9 +1,26 @@
 'use strict';
 const Heap = require('./heap');
+const Node = require('./node');
 
 class Min extends Heap {
   _areOrdered(parentIndex, childIndex) {
     return this._data[parentIndex].key - this._data[childIndex].key < 0;
+  }
+
+  insert(key, value) {
+    const node = new Node(key, value);
+    this._data.push(node);
+
+    let index = this.size - 1;
+    let parentIndex = this.parentIndex(index);
+
+    while (parentIndex >= 0 && !this._areOrdered(parentIndex, index)) {
+      this._swap(parentIndex, index);
+      index = parentIndex;
+      parentIndex = this.parentIndex(index);
+    }
+
+    return this;
   }
 }
 

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -64,7 +64,9 @@ declare namespace min {
     new <T = any>(): Instance<T>;
   }
 
-  export interface Instance<T = any> extends heap.Instance<T> {}
+  export interface Instance<T = any> extends heap.Instance<T> {
+    insert(key: number, value: T): this;
+  }
 }
 
 declare namespace mheap {


### PR DESCRIPTION
## Description

The PR introduces the following new binary method: 

- `Min#insert(key, value)`

Mutates the min heap by inserting a new at the appropriate location. Returns the min heap itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
