### PR TITLE
Add new `Heap#childrenIndices(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -48,6 +48,22 @@ class Heap {
     return children;
   }
 
+  childrenIndices(index) {
+    const indices = {};
+    const left = this.leftIndex(index);
+    const right = this.rightIndex(index);
+
+    if (left < this.size) {
+      indices.left = left;
+    }
+
+    if (right < this.size) {
+      indices.right = right;
+    }
+
+    return indices;
+  }
+
   clear() {
     this._data = [];
     return this;

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -19,6 +19,7 @@ declare namespace heap {
     readonly root: Node<T> | undefined;
     readonly size: number;
     children(index: number): { left?: Node<T>; right?: Node<T> };
+    childrenIndices(index: number): { left?: number; right?: number };
     clear(): this;
     degree(index: number): Degree;
     fullNodes(): Node<T>[];


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#childrenIndices(index)`

Returns an object `{ left?: number, right?: number }`, contacting the indices of the children of the parent node, corresponding to the given index of the unique zero-indexed array representation of the binary heap. The returned object contains a `left` property corresponding to the index of the left child, only if the child is present, and a `right` property corresponding to the index of the right child, only if the child is present as well.

Also, the corresponding TypeScript ambient declarations are included in the PR.