### PR TITLE
Add new `Heap#minChildIndex(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -165,6 +165,20 @@ class Heap {
     return (2 * index) + 1;
   }
 
+  minChildIndex(index) {
+    const {left, right} = this.childrenIndices(index);
+
+    if (left) {
+      if (right && this._compare(left, right) > 0) {
+        return right;
+      }
+
+      return left;
+    }
+
+    return -1;
+  }
+
   node(index) {
     return this._data[index];
   }

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -36,6 +36,7 @@ declare namespace heap {
     leafNodes(): Node<T>[];
     left(index: number): Node<T> | undefined;
     leftIndex(index: number): number;
+    minChildIndex(index: number): number;
     node(index: number): Node<T> | undefined;
     parent(index: number): Node<T> | undefined;
     parentIndex(index: number): number;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#minChildIndex(index)`

Returns the index of the child with the smallest `key` value of the parent node, corresponding to the given index of the unique zero-indexed array representation of the binary heap. If the parent node is a leaf then `-1` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.