### PR TITLE
Add new `Heap#maxChild(index)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -165,6 +165,10 @@ class Heap {
     return (2 * index) + 1;
   }
 
+  maxChild(index) {
+    return this._data[this.maxChildIndex(index)];
+  }
+
   maxChildIndex(index) {
     const {left, right} = this.childrenIndices(index);
 

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -36,6 +36,7 @@ declare namespace heap {
     leafNodes(): Node<T>[];
     left(index: number): Node<T> | undefined;
     leftIndex(index: number): number;
+    maxChild(index: number): Node<T> | undefined;
     maxChildIndex(index: number): number;
     minChildIndex(index: number): number;
     node(index: number): Node<T> | undefined;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#maxChild(index)`

Returns the child with the greatest `key` value of the parent node, corresponding to the given index of the unique zero-indexed array representation of the binary heap. If the parent node is a leaf then `undefined` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.