### PR TITLE
Add new `Max#extractMax()` class method (#3)

### DIFF
--- a/src/max.js
+++ b/src/max.js
@@ -15,6 +15,25 @@ class Max extends Heap {
     return true;
   }
 
+  extractMax() {
+    if (this.size <= 1) {
+      return this._data.shift();
+    }
+
+    const {root: max} = this;
+    this._data[0] = this._data.pop();
+
+    let index = 0;
+
+    while (!this._isMaxOrdered(index)) {
+      const maxIndex = this.maxChildIndex(index);
+      this._swap(index, maxIndex);
+      index = maxIndex;
+    }
+
+    return max;
+  }
+
   insert(key, value) {
     const node = new Node(key, value);
     this._data.push(node);

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -62,6 +62,7 @@ declare namespace max {
   }
 
   export interface Instance<T = any> extends heap.Instance<T> {
+    extractMax(): Node<T> | undefined;
     insert(key: number, value: T): this;
   }
 }


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Max#extractMax()`

Mutates the binary max heap by removing and returning the max/root node of the heap while properly readjusting the heap in order for it to fulfill the two **shape** & **heap** **properties**.


Also, the corresponding TypeScript ambient declarations are included in the PR.
