### PR TITLE
Add new `Max#remove(index)` class method (#3)

### DIFF
--- a/src/max.js
+++ b/src/max.js
@@ -49,6 +49,25 @@ class Max extends Heap {
 
     return this;
   }
+
+  remove(index) {
+    if (index >= 0 && index < this.size) {
+      if (index === this.size - 1) {
+        this._data.pop();
+      } else {
+        let currentIndex = index;
+        this._data[currentIndex] = this._data.pop();
+
+        while (!this._isMaxOrdered(currentIndex)) {
+          const maxIndex = this.maxChildIndex(currentIndex);
+          this._swap(currentIndex, maxIndex);
+          currentIndex = maxIndex;
+        }
+      }
+    }
+
+    return this;
+  }
 }
 
 module.exports = Max;

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -64,6 +64,7 @@ declare namespace max {
   export interface Instance<T = any> extends heap.Instance<T> {
     extractMax(): Node<T> | undefined;
     insert(key: number, value: T): this;
+    remove(index: number): this;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Max#remove(index)`

Mutates the binary max heap by removing the node corresponding to the given index, of the unique zero-indexed array representation of the binary heap, and properly readjusts the heap in order for it to fulfill the two **shape** & **heap** **properties**. Returns the heap itself.


Also, the corresponding TypeScript ambient declarations are included in the PR.
