### PR TITLE
Add new `Max#extract(index)` class method (#3)

### DIFF
--- a/src/max.js
+++ b/src/max.js
@@ -15,6 +15,12 @@ class Max extends Heap {
     return true;
   }
 
+  extract(index) {
+    const node = this._data[index];
+    this.remove(index);
+    return node;
+  }
+
   extractMax() {
     if (this.size <= 1) {
       return this._data.shift();

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -62,6 +62,7 @@ declare namespace max {
   }
 
   export interface Instance<T = any> extends heap.Instance<T> {
+    extract(index): Node<T> | undefined;
     extractMax(): Node<T> | undefined;
     insert(key: number, value: T): this;
     remove(index: number): this;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Max#extract(index)`

Mutates the binary max heap by removing the node corresponding to the given index, of the unique zero-indexed array representation of the binary heap, and properly readjusts the heap in order for it to fulfill the two **shape** & **heap** **properties**. Returns the removed node, if the node is found, or `undefined` if it is not.

Also, the corresponding TypeScript ambient declarations are included in the PR.
