### PR TITLE
Add new `Min#remove(index)` class method (#3)

### DIFF
--- a/src/min.js
+++ b/src/min.js
@@ -30,6 +30,25 @@ class Min extends Heap {
 
     return this;
   }
+
+  remove(index) {
+    if (index >= 0 && index < this.size) {
+      if (index === this.size - 1) {
+        this._data.pop();
+      } else {
+        let currentIndex = index;
+        this._data[currentIndex] = this._data.pop();
+
+        while (!this._isMinOrdered(currentIndex)) {
+          const minIndex = this.minChildIndex(currentIndex);
+          this._swap(currentIndex, minIndex);
+          currentIndex = minIndex;
+        }
+      }
+    }
+
+    return this;
+  }
 }
 
 module.exports = Min;

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -78,6 +78,7 @@ declare namespace min {
 
   export interface Instance<T = any> extends heap.Instance<T> {
     insert(key: number, value: T): this;
+    remove(index: number): this;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Min#remove(index)`

Mutates the binary min heap by removing the node corresponding to the given index, of the unique zero-indexed array representation of the binary heap, and properly readjusts the heap in order for it to fulfill the two **shape** & **heap** **properties**. Returns the heap itself.


Also, the corresponding TypeScript ambient declarations are included in the PR.
