### PR TITLE
Add new `Min#extract(index)` class method (#3)

### DIFF
--- a/src/min.js
+++ b/src/min.js
@@ -15,6 +15,12 @@ class Min extends Heap {
     return true;
   }
 
+  extract(index) {
+    const node = this._data[index];
+    this.remove(index);
+    return node;
+  }
+
   insert(key, value) {
     const node = new Node(key, value);
     this._data.push(node);

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -77,6 +77,7 @@ declare namespace min {
   }
 
   export interface Instance<T = any> extends heap.Instance<T> {
+    extract(index: number): Node<T> | undefined;
     insert(key: number, value: T): this;
     remove(index: number): this;
   }


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Min#extract(index)`

Mutates the binary min heap by removing the node corresponding to the given index, of the unique zero-indexed array representation of the binary heap, and properly readjusts the heap in order for it to fulfill the two **shape** & **heap** **properties**. Returns the removed node, if the node is found, or `undefined` if it is not.

Also, the corresponding TypeScript ambient declarations are included in the PR.
