### PR TITLE
Add new `Min#extractMin()` class method (#3)

### DIFF
--- a/src/min.js
+++ b/src/min.js
@@ -21,6 +21,10 @@ class Min extends Heap {
     return node;
   }
 
+  extractMin() {
+    return this.extract(0);
+  }
+
   insert(key, value) {
     const node = new Node(key, value);
     this._data.push(node);

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -78,6 +78,7 @@ declare namespace min {
 
   export interface Instance<T = any> extends heap.Instance<T> {
     extract(index: number): Node<T> | undefined;
+    extractMin(): Node<T> | undefined;
     insert(key: number, value: T): this;
     remove(index: number): this;
   }


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Min#extractMin()`

Mutates the binary min heap by removing and returning the min/root node of the heap while properly readjusting the heap in order for it to fulfill the two **shape** & **heap** **properties**.


Also, the corresponding TypeScript ambient declarations are included in the PR.
