### PR TITLE
Add new `Heap#levelOrder(fn)` class method

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -165,6 +165,11 @@ class Heap {
     return (2 * index) + 1;
   }
 
+  levelOrder(fn) {
+    this._data.forEach(node => fn(node));
+    return this;
+  }
+
   maxChild(index) {
     return this._data[this.maxChildIndex(index)];
   }

--- a/test/max/empty.js
+++ b/test/max/empty.js
@@ -58,6 +58,12 @@ test('leafNodes', t => {
   t.deepEqual(heap.leafNodes(), []);
 });
 
+test('levelOrder', t => {
+  const array = [];
+  heap.levelOrder(x => array.push(x));
+  t.deepEqual(array, []);
+});
+
 test('node', t => {
   t.is(heap.node(0), undefined);
 });

--- a/test/max/multiple.js
+++ b/test/max/multiple.js
@@ -137,6 +137,12 @@ test('leftIndex', t => {
   t.is(heap.leftIndex(2), 5);
 });
 
+test('levelOrder', t => {
+  const array = [];
+  heap.levelOrder(x => array.push(x));
+  t.deepEqual(array, [new Node(15, 'A'), new Node(10, 'B'), new Node(5, 'C'), new Node(7, 'D')]);
+});
+
 test('maxChild', t => {
   t.deepEqual(heap.maxChild(0), new Node(10, 'B'));
   t.deepEqual(heap.maxChild(1), new Node(7, 'D'));

--- a/test/max/single.js
+++ b/test/max/single.js
@@ -122,6 +122,12 @@ test('leftIndex', t => {
   t.is(heap.leftIndex(0), 1);
 });
 
+test('levelOrder', t => {
+  const array = [];
+  heap.levelOrder(x => array.push(x));
+  t.deepEqual(array, [new Node(15, 'A')]);
+});
+
 test('maxChild', t => {
   t.is(heap.maxChild(0), undefined);
 });

--- a/test/min/empty.js
+++ b/test/min/empty.js
@@ -58,6 +58,12 @@ test('leafNodes', t => {
   t.deepEqual(heap.leafNodes(), []);
 });
 
+test('levelOrder', t => {
+  const array = [];
+  heap.levelOrder(x => array.push(x));
+  t.deepEqual(array, []);
+});
+
 test('node', t => {
   t.is(heap.node(0), undefined);
 });

--- a/test/min/multiple.js
+++ b/test/min/multiple.js
@@ -137,6 +137,12 @@ test('leftIndex', t => {
   t.is(heap.leftIndex(2), 5);
 });
 
+test('levelOrder', t => {
+  const array = [];
+  heap.levelOrder(x => array.push(x));
+  t.deepEqual(array, [new Node(5, 'C'), new Node(7, 'D'), new Node(10, 'B'), new Node(15, 'A')]);
+});
+
 test('maxChild', t => {
   t.deepEqual(heap.maxChild(0), new Node(10, 'B'));
   t.deepEqual(heap.maxChild(1), new Node(15, 'A'));

--- a/test/min/single.js
+++ b/test/min/single.js
@@ -122,6 +122,12 @@ test('leftIndex', t => {
   t.is(heap.leftIndex(0), 1);
 });
 
+test('levelOrder', t => {
+  const array = [];
+  heap.levelOrder(x => array.push(x));
+  t.deepEqual(array, [new Node(1, 'A')]);
+});
+
 test('maxChild', t => {
   t.is(heap.maxChild(0), undefined);
 });

--- a/types/mheap.d.ts
+++ b/types/mheap.d.ts
@@ -36,6 +36,7 @@ declare namespace heap {
     leafNodes(): Node<T>[];
     left(index: number): Node<T> | undefined;
     leftIndex(index: number): number;
+    levelOrder(fn: (x: Node<T>) => void): this;
     maxChild(index: number): Node<T> | undefined;
     maxChildIndex(index: number): number;
     minChild(index: number): Node<T> | undefined;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Heap#levelOrder(fn)`

Traverses the binary heap in level-order (BFT) and applies the `fn` function to each traversed node. 
Returns the heap itself at the end of the traversal.

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.
